### PR TITLE
Alembic now runs in the Docker

### DIFF
--- a/back-fastapi/Dockerfile
+++ b/back-fastapi/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install --no-cache-dir --upgrade -r /requirements.txt
 
 COPY ./ /
 
-CMD ["uvicorn", "main:app", "--host", "back_fastapi", "--port", "8000"]
+CMD ["sh", "-c", "uvicorn main:app --host back_fastapi --port 8000 && alembic upgrade head"]


### PR DESCRIPTION
Now tables are created in Docker database on container startup.